### PR TITLE
Add IPC RPC helpers for harmonic_nxo

### DIFF
--- a/custom_plugins/harmonic_nxo/src/ipc_rpc.rs
+++ b/custom_plugins/harmonic_nxo/src/ipc_rpc.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub type RpcFn = dyn Fn(Vec<Value>) -> Value + Send + Sync;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RpcAction {
+    SetRequestedFunction { id: u32, name: String, args: Vec<Value> },
+    SetFunctionResult { id: u32, result: Value },
+    SendFunctionResult { id: u32 },
+}
+
+pub struct IpcRpc {
+    funcs: HashMap<String, Box<RpcFn>>,
+    pending_send: HashMap<u32, Value>,
+    incoming: HashMap<u32, Value>,
+    next_id: u32,
+}
+
+impl IpcRpc {
+    pub fn new() -> Self {
+        Self {
+            funcs: HashMap::new(),
+            pending_send: HashMap::new(),
+            incoming: HashMap::new(),
+            next_id: 0,
+        }
+    }
+
+    pub fn register_function<F>(&mut self, name: impl Into<String>, func: F)
+    where
+        F: Fn(Vec<Value>) -> Value + Send + Sync + 'static,
+    {
+        self.funcs.insert(name.into(), Box::new(func));
+    }
+
+    pub fn handle_action<F>(&mut self, action: RpcAction, mut send: F)
+    where
+        F: FnMut(RpcAction),
+    {
+        match action {
+            RpcAction::SetRequestedFunction { id, name, args } => {
+                if let Some(func) = self.funcs.get(&name) {
+                    let result = func(args);
+                    self.pending_send.insert(id, result);
+                } else {
+                    self.pending_send.insert(id, Value::Null);
+                }
+            }
+            RpcAction::SendFunctionResult { id } => {
+                if let Some(result) = self.pending_send.remove(&id) {
+                    send(RpcAction::SetFunctionResult { id, result });
+                }
+            }
+            RpcAction::SetFunctionResult { id, result } => {
+                self.incoming.insert(id, result);
+            }
+        }
+    }
+
+    pub fn call_remote_function<F>(&mut self, mut send: F, name: impl Into<String>, args: Vec<Value>) -> u32
+    where
+        F: FnMut(RpcAction),
+    {
+        let id = self.next_id;
+        self.next_id += 1;
+        send(RpcAction::SetRequestedFunction {
+            id,
+            name: name.into(),
+            args,
+        });
+        send(RpcAction::SendFunctionResult { id });
+        id
+    }
+
+    pub fn take_result(&mut self, id: u32) -> Option<Value> {
+        self.incoming.remove(&id)
+    }
+}

--- a/custom_plugins/harmonic_nxo/web-gui/src/utils/ipc-rpc.ts
+++ b/custom_plugins/harmonic_nxo/web-gui/src/utils/ipc-rpc.ts
@@ -1,0 +1,65 @@
+export type RpcSend = (payload: Record<string, unknown>) => void;
+
+export type RpcAction =
+  | { type: 'SetRequestedFunction'; id: number; name: string; args: unknown[] }
+  | { type: 'SetFunctionResult'; id: number; result: unknown }
+  | { type: 'SendFunctionResult'; id: number };
+
+export class IpcRpc {
+  private funcs: Record<string, (...args: any[]) => any | Promise<any>> = {};
+  private pendingSend = new Map<number, unknown>();
+  private incoming = new Map<number, unknown>();
+  private nextId = 0;
+
+  constructor(private send: RpcSend) {}
+
+  registerFunction(name: string, fn: (...args: any[]) => any | Promise<any>) {
+    this.funcs[name] = fn;
+  }
+
+  callRemoteFunction(name: string, args: unknown[]): number {
+    const id = this.nextId++;
+    this.send({ type: 'SetRequestedFunction', id, name, args });
+    this.send({ type: 'SendFunctionResult', id });
+    return id;
+  }
+
+  tryTakeResult(id: number): unknown | undefined {
+    const res = this.incoming.get(id);
+    if (res !== undefined) {
+      this.incoming.delete(id);
+    }
+    return res;
+  }
+
+  handleMessage(msg: RpcAction) {
+    switch (msg.type) {
+      case 'SetRequestedFunction': {
+        const fn = this.funcs[msg.name];
+        if (fn) {
+          Promise.resolve(fn(...msg.args)).then((r) => {
+            this.pendingSend.set(msg.id, r);
+          });
+        } else {
+          this.pendingSend.set(msg.id, null);
+        }
+        break;
+      }
+      case 'SendFunctionResult': {
+        if (this.pendingSend.has(msg.id)) {
+          this.send({
+            type: 'SetFunctionResult',
+            id: msg.id,
+            result: this.pendingSend.get(msg.id),
+          });
+          this.pendingSend.delete(msg.id);
+        }
+        break;
+      }
+      case 'SetFunctionResult': {
+        this.incoming.set(msg.id, msg.result);
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add generalized IPC RPC helper in `ipc_rpc.rs` for the harmonic_nxo backend
- add matching TypeScript helper under the web GUI

## Testing
- `cargo check -p harmonic_nxo` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878e503371483298f782da8a86f6a69