### PR TITLE
Periodic MIDI state updates

### DIFF
--- a/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
+++ b/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
@@ -49,6 +49,9 @@ function App() {
       RespondGain: async (payload: { gain: number }) => {
         setGain(payload.gain);
       },
+      MidiStateUpdate: async (payload: { states: boolean[] }) => {
+        setMidiStates(payload.states);
+      },
     };
   }, []) as object as Record<
     string,


### PR DESCRIPTION
## Summary
- expose shared keyboard state between DSP and GUI
- update keyboard state on note on/off
- send keyboard state to GUI every 100ms
- handle `MidiStateUpdate` message in the web UI

## Testing
- `cargo check --workspace` *(fails: failed to fetch git dependencies)*
- `pnpm lint` in `custom_plugins/harmonic_nxo/web-gui` *(fails: module '@eslint/js' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881867f71f88329acb930351c663e85