### PR TITLE
Add Lua worker execution

### DIFF
--- a/custom_plugins/harmonic_nxo/web-gui/package.json
+++ b/custom_plugins/harmonic_nxo/web-gui/package.json
@@ -21,7 +21,8 @@
     "react-icons": "^5.5.0",
     "react-slider": "^2.0.6",
     "style-props-html": "^0.0.7",
-    "vite-plugin-string": "^1.2.3"
+    "vite-plugin-string": "^1.2.3",
+    "wasmoon": "^1.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/custom_plugins/harmonic_nxo/web-gui/src/utils/validateLuaResult.ts
+++ b/custom_plugins/harmonic_nxo/web-gui/src/utils/validateLuaResult.ts
@@ -1,0 +1,17 @@
+export interface HarmonicParams {
+  [key: string]: unknown;
+}
+
+export interface HarmonicResult {
+  [frequency: number]: HarmonicParams;
+}
+
+export function isHarmonicResult(obj: unknown): obj is HarmonicResult {
+  if (obj === null || typeof obj !== 'object') return false;
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const freq = Number(k);
+    if (!Number.isFinite(freq)) return false;
+    if (typeof v !== 'object' || v === null || Array.isArray(v)) return false;
+  }
+  return true;
+}

--- a/custom_plugins/harmonic_nxo/web-gui/src/workers/luaWorker.ts
+++ b/custom_plugins/harmonic_nxo/web-gui/src/workers/luaWorker.ts
@@ -1,0 +1,15 @@
+import { LuaFactory } from 'wasmoon';
+
+const factory = new LuaFactory();
+
+self.onmessage = async (ev: MessageEvent<{ id: number; code: string }>) => {
+  const { id, code } = ev.data;
+  try {
+    const lua = await factory.createEngine();
+    const result = await lua.doString(code);
+    self.postMessage({ id, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.stack || err.message : String(err);
+    self.postMessage({ id, error: message });
+  }
+};


### PR DESCRIPTION
## Summary
- add `wasmoon` dependency for lua execution
- create lua worker to run code in an isolated environment
- validate lua results and display errors or results in UI
- send validated results to backend

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: cannot find module 'react')*
- `cargo check` *(fails: network failure while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68818a24b4908329b39d983f845aae6e