### PR TITLE
Display Lua harmonics as table in web UI

### DIFF
--- a/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
+++ b/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
@@ -10,6 +10,7 @@ import exampleLuaGuitar from "./exampleLua/guitar.lua?raw";
 import { MdPlayArrow } from "react-icons/md";
 import { css } from "@emotion/react";
 import PianoWidget from "./components/PianoWidget";
+import HarmonicsTable from "./components/HarmonicsTable";
 import {
   isHarmonicResult,
   type HarmonicResult,
@@ -303,7 +304,7 @@ function App() {
         <Div padding="0.5rem" overflow="auto">
           {compileError && <pre style={{ color: "red" }}>{compileError}</pre>}
           {!compileError && compileResult && (
-            <pre>{JSON.stringify(compileResult, null, 2)}</pre>
+            <HarmonicsTable result={compileResult} />
           )}
         </Div>
       </Div>

--- a/custom_plugins/harmonic_nxo/web-gui/src/components/HarmonicsTable.tsx
+++ b/custom_plugins/harmonic_nxo/web-gui/src/components/HarmonicsTable.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { type HarmonicResult } from "../utils/validateLuaResult";
+
+interface HarmonicsTableProps {
+  result: HarmonicResult;
+}
+
+function formatHeader(name: string): string {
+  if (/db$/i.test(name)) {
+    return `${name} (dB)`;
+  }
+  if (/seconds?$|sec$/i.test(name)) {
+    return `${name} (s)`;
+  }
+  return name;
+}
+
+export default function HarmonicsTable({ result }: HarmonicsTableProps) {
+  const harmonicIndices = Object.keys(result)
+    .map((k) => Number(k))
+    .sort((a, b) => a - b);
+
+  if (harmonicIndices.length === 0) return null;
+
+  // Determine all columns present in the result
+  const columns = Array.from(
+    new Set(
+      harmonicIndices.flatMap((idx) => Object.keys(result[idx]))
+    )
+  );
+
+  return (
+    <table
+      style={{
+        borderCollapse: "collapse",
+        width: "100%",
+        tableLayout: "auto",
+      }}
+    >
+      <thead>
+        <tr>
+          <th style={{ border: "1px solid #ccc", padding: "0.25rem" }}>Harmonic</th>
+          {columns.map((col) => (
+            <th
+              key={col}
+              style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+            >
+              {formatHeader(col)}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {harmonicIndices.map((idx) => (
+          <tr key={idx}>
+            <td style={{ border: "1px solid #ccc", padding: "0.25rem" }}>{idx}</td>
+            {columns.map((col) => (
+              <td
+                key={col}
+                style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+              >
+                {String((result[idx] as Record<string, unknown>)[col] ?? "")}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- add `HarmonicsTable` component to render Lua results
- show the table instead of JSON in the Harmonic NXO web GUI

## Testing
- `cargo test --workspace --tests --quiet` *(fails: failed to fetch dependencies)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881a8162dec8329931d55ec532e5da8