### PR TITLE
Add stateless ADSR envelope

### DIFF
--- a/custom_plugins/harmonic_nxo/src/ADSR.rs
+++ b/custom_plugins/harmonic_nxo/src/ADSR.rs
@@ -1,209 +1,72 @@
 use std::f32::consts::E;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum State {
-    Idle,
-    Attack,
-    Decay,
-    Sustain,
-    Release,
+/// How many time constants should pass before the envelope is considered
+/// finished with a stage. The higher this number, the closer the envelope
+/// will get to the target value at the end of the stage.
+pub const NUM_TAU_FINISHED: f32 = 5.0;
+
+/// Parameters for an ADSR envelope.
+#[derive(Debug, Clone, Copy)]
+pub struct EnvelopeParams {
+    pub attack: f32,
+    pub decay: f32,
+    pub sustain: f32,
+    pub release: f32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CurveType {
-    Exponential,
-    Linear,
+fn tau(time: f32) -> f32 {
+    if time <= 0.0 {
+        // Avoid division by zero. A zero time constant results in an
+        // instantaneous jump to the target.
+        f32::EPSILON
+    } else {
+        time / NUM_TAU_FINISHED
+    }
 }
 
-pub struct Adsr {
-    state: State,
-    sustain_level: f32,
-    level: f32,
-    sample_rate: f32,
-    attack_time: f32,
-    decay_time: f32,
-    release_time: f32,
-    alpha_a: f32,
-    alpha_d: f32,
-    alpha_r: f32,
-    attack_elapsed_samples: usize,
-    decay_elapsed_samples: usize,
-    release_elapsed_samples: usize,
-    release_start_level: f32,
-    curve_type: CurveType,
+fn pre_release_value(t: f32, params: &EnvelopeParams) -> f32 {
+    if t <= params.attack {
+        let tau_a = tau(params.attack);
+        1.0 - (-t / tau_a).exp()
+    } else if t <= params.attack + params.decay {
+        let tau_d = tau(params.decay);
+        let dt = t - params.attack;
+        params.sustain + (1.0 - params.sustain) * (-dt / tau_d).exp()
+    } else {
+        params.sustain
+    }
 }
 
-const TAU_UNTIL_FINISHED: f32 = 5.0;
-const EPSILON: f32 = 1e-5;
-
-impl Adsr {
-    fn compute_alpha(time_secs: f32, sample_rate: f32) -> f32 {
-        let tau = time_secs / TAU_UNTIL_FINISHED;
-        1.0 - (-1.0 / (tau * sample_rate)).exp()
+fn release_value(start_level: f32, t: f32, release: f32) -> f32 {
+    if release <= 0.0 {
+        0.0
+    } else {
+        let tau_r = tau(release);
+        start_level * (-t / tau_r).exp()
     }
+}
 
-    pub fn new(
-        attack_time: f32,
-        decay_time: f32,
-        sustain: f32,
-        release_time: f32,
-        sample_rate: f32,
-        curve_type: CurveType,
-    ) -> Self {
-        let alpha_a = Self::compute_alpha(attack_time, sample_rate);
-        let alpha_d = Self::compute_alpha(decay_time, sample_rate);
-        let alpha_r = Self::compute_alpha(release_time, sample_rate);
-
-        Self {
-            state: State::Idle,
-            sustain_level: sustain,
-            level: 0.0,
-            sample_rate,
-            attack_time,
-            decay_time,
-            release_time,
-            alpha_a,
-            alpha_d,
-            alpha_r,
-            attack_elapsed_samples: 0,
-            decay_elapsed_samples: 0,
-            release_elapsed_samples: 0,
-            release_start_level: 0.0,
-            curve_type,
+/// Compute the envelope's amplitude at time `t_since_on` (seconds) given an
+/// optional `note_off` time (seconds since note on).
+pub fn value_at(t_since_on: f32, note_off: Option<f32>, params: &EnvelopeParams) -> f32 {
+    if let Some(off) = note_off {
+        if t_since_on >= off {
+            let start_level = pre_release_value(off, params);
+            release_value(start_level, t_since_on - off, params.release)
+        } else {
+            pre_release_value(t_since_on, params)
         }
+    } else {
+        pre_release_value(t_since_on, params)
     }
+}
 
-    pub fn trigger(&mut self) {
-        self.state = State::Attack;
-        self.attack_elapsed_samples = 0;
-        self.decay_elapsed_samples = 0;
-        self.release_elapsed_samples = 0;
-    }
-
-    pub fn release(&mut self) {
-        if self.state != State::Idle {
-            self.state = State::Release;
-            self.release_elapsed_samples = 0;
-            self.release_start_level = self.level;
-        }
-    }
-
-    pub fn reset(&mut self) {
-        self.state = State::Idle;
-        self.level = 0.0;
-        self.attack_elapsed_samples = 0;
-        self.decay_elapsed_samples = 0;
-        self.release_elapsed_samples = 0;
-    }
-
-    pub fn next(&mut self) -> f32 {
-        match self.state {
-            State::Idle => {
-                self.level = 0.0;
-            }
-            State::Attack => {
-                match self.curve_type {
-                    CurveType::Exponential => {
-                        self.level = self.alpha_a * 1.0 + (1.0 - self.alpha_a) * self.level;
-                    }
-                    CurveType::Linear => {
-                        let total = (self.attack_time * self.sample_rate).ceil();
-                        self.level += 1.0 / total;
-                    }
-                }
-                self.attack_elapsed_samples += 1;
-                let total_attack_samples = (self.attack_time * self.sample_rate).ceil() as usize;
-                if self.attack_elapsed_samples >= total_attack_samples {
-                    self.level = 1.0;
-                    self.state = State::Decay;
-                }
-            }
-            State::Decay => {
-                match self.curve_type {
-                    CurveType::Exponential => {
-                        self.level = self.alpha_d * self.sustain_level + (1.0 - self.alpha_d) * self.level;
-                    }
-                    CurveType::Linear => {
-                        let total = (self.decay_time * self.sample_rate).ceil();
-                        self.level -= (1.0 - self.sustain_level) / total;
-                    }
-                }
-                self.decay_elapsed_samples += 1;
-                let total_decay_samples = (self.decay_time * self.sample_rate).ceil() as usize;
-                if self.decay_elapsed_samples >= total_decay_samples {
-                    self.level = self.sustain_level;
-                    self.state = State::Sustain;
-                }
-            }
-            State::Sustain => {
-                self.level = self.sustain_level;
-            }
-            State::Release => {
-                match self.curve_type {
-                    CurveType::Exponential => {
-                        self.level = self.alpha_r * 0.0 + (1.0 - self.alpha_r) * self.level;
-                    }
-                    CurveType::Linear => {
-                        let total = (self.release_time * self.sample_rate).ceil();
-                        self.level -= self.release_start_level / total;
-                    }
-                }
-                self.release_elapsed_samples += 1;
-                let total_release_samples = (self.release_time * self.sample_rate).ceil() as usize;
-                if self.release_elapsed_samples >= total_release_samples || self.level < EPSILON {
-                    self.level = 0.0;
-                    self.state = State::Idle;
-                }
-            }
-        }
-        self.level
-    }
-
-    pub fn is_idle(&self) -> bool {
-        self.state == State::Idle
-    }
-
-    pub fn is_finished(&self) -> bool {
-        self.state == State::Idle && self.level < EPSILON
-    }
-
-    pub fn get_state(&self) -> State {
-        self.state
-    }
-
-    pub fn get_level(&self) -> f32 {
-        self.level
-    }
-
-    // Dynamic setters
-
-    pub fn set_attack_time(&mut self, attack_time: f32) {
-        self.attack_time = attack_time;
-        self.alpha_a = Self::compute_alpha(attack_time, self.sample_rate);
-    }
-
-    pub fn set_decay_time(&mut self, decay_time: f32) {
-        self.decay_time = decay_time;
-        self.alpha_d = Self::compute_alpha(decay_time, self.sample_rate);
-    }
-
-    pub fn set_release_time(&mut self, release_time: f32) {
-        self.release_time = release_time;
-        self.alpha_r = Self::compute_alpha(release_time, self.sample_rate);
-    }
-
-    pub fn set_sustain_level(&mut self, sustain: f32) {
-        self.sustain_level = sustain;
-    }
-
-    pub fn set_sample_rate(&mut self, sample_rate: f32) {
-        self.sample_rate = sample_rate;
-        self.alpha_a = Self::compute_alpha(self.attack_time, sample_rate);
-        self.alpha_d = Self::compute_alpha(self.decay_time, sample_rate);
-        self.alpha_r = Self::compute_alpha(self.release_time, sample_rate);
-    }
-
-    pub fn set_curve_type(&mut self, curve_type: CurveType) {
-        self.curve_type = curve_type;
+/// Returns `true` if the envelope has effectively finished after
+/// `t_since_on` seconds.
+pub fn is_finished(t_since_on: f32, note_off: Option<f32>, params: &EnvelopeParams) -> bool {
+    if let Some(off) = note_off {
+        t_since_on >= off + params.release
+    } else {
+        false
     }
 }

--- a/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
+++ b/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
@@ -55,10 +55,13 @@ function App() {
       } else if (isNXODefinition(e.data.result)) {
         setCompileError(null);
         setCompileResult(e.data.result);
-        // (window as object as NIHPlugWebviewWindow).sendToPlugin({
-        //   type: "LuaResult",
-        //   data: e.data.result,
-        // });
+        const win = window as object as NIHPlugWebviewWindow;
+        if (typeof win.sendToPlugin === "function") {
+          win.sendToPlugin({
+            type: "SetNxoDefinition",
+            definition: e.data.result,
+          });
+        }
       } else {
         setCompileError(
 `


### PR DESCRIPTION
## Summary
- replace stateful ADSR with stateless math functions
- compute envelope level for each voice from timestamps
- update voice handling to use new envelope helpers

## Testing
- `cargo check -p harmonic_nxo` *(failed: failed to get `assert_no_alloc` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68844bbd99b08329a87bb7e1b04c6023