### PR TITLE
Add fail-safe remote logger

### DIFF
--- a/custom_plugins/harmonic_nxo/Cargo.toml
+++ b/custom_plugins/harmonic_nxo/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0"
 nih_plug_webview = { path = "../../nih-plug-webview" }
 ordered-float = "2"
+ureq = { version = "2" }

--- a/custom_plugins/harmonic_nxo/README.md
+++ b/custom_plugins/harmonic_nxo/README.md
@@ -1,0 +1,15 @@
+# Harmonic NXO
+
+This plugin uses a small logging server for development. The server is powered by [Pino](https://github.com/pinojs/pino) and listens on **port 9099**.
+
+## Running the logging server
+
+From the repository root run:
+
+```bash
+pnpm install
+pnpm start-log-server
+```
+
+Logs are printed to the console. Any time the frontend sends a new harmonic definition, the plugin posts a JSON payload to `http://localhost:9099/log` which will appear in the server output. If the server isn't running the plugin simply ignores the error, so logging never interrupts normal operation.
+

--- a/custom_plugins/harmonic_nxo/src/lib.rs
+++ b/custom_plugins/harmonic_nxo/src/lib.rs
@@ -1,5 +1,7 @@
 mod ADSR;
+mod remote_logging;
 use ADSR::{EnvelopeParams, is_finished, value_at};
+use remote_logging::RemoteLogger;
 use nih_plug_webview::*;
 
 use nih_plug::prelude::*;
@@ -241,6 +243,7 @@ pub struct HarmonicNxo {
     ts: u64,
     midi_states: Arc<Vec<AtomicBool>>,
     last_midi_send: Arc<Mutex<Instant>>,
+    remote_logger: RemoteLogger,
 }
 
 impl Default for HarmonicNxo {
@@ -255,6 +258,7 @@ impl Default for HarmonicNxo {
             ts: 0,
             midi_states: Arc::new((0..128).map(|_| AtomicBool::new(false)).collect()),
             last_midi_send: Arc::new(Mutex::new(Instant::now())),
+            remote_logger: RemoteLogger::new(9099),
         }
     }
 }
@@ -361,6 +365,7 @@ impl Plugin for HarmonicNxo {
         let midi_states = self.midi_states.clone();
         let last_midi_send = self.last_midi_send.clone();
         let nxo_def = self.nxo_definition.clone();
+        let logger = self.remote_logger.clone();
         let editor = WebViewEditor::new(HTMLSource::URL("http://localhost:5173"), (1000, 750))
             .with_developer_mode(true)
             .with_keyboard_handler(move |event| {
@@ -378,8 +383,12 @@ impl Plugin for HarmonicNxo {
                             }
 
                             Action::SetNxoDefinition { definition } => {
-                                if let Ok(nxo) = NxoDefinition::try_from(definition) {
+                                if let Ok(nxo) = NxoDefinition::try_from(definition.clone()) {
                                     *nxo_def.lock().unwrap() = nxo;
+                                    logger.log(&json!({
+                                        "event": "SetNxoDefinition",
+                                        "definition": definition
+                                    }));
                                 }
                             }
 

--- a/custom_plugins/harmonic_nxo/src/remote_logging.rs
+++ b/custom_plugins/harmonic_nxo/src/remote_logging.rs
@@ -1,0 +1,37 @@
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Clone)]
+/// Helper for sending JSON logs to a local web server.
+///
+/// The logger is best-effort: if the server isn't reachable then any errors are
+/// ignored so logging never interferes with the plugin.
+#[derive(Clone)]
+pub struct RemoteLogger {
+    url: String,
+    agent: ureq::Agent,
+}
+
+impl RemoteLogger {
+    /// Create a new logger for the given port on localhost.
+    pub fn new(port: u16) -> Self {
+        Self {
+            url: format!("http://localhost:{port}/log"),
+            agent: ureq::AgentBuilder::new()
+                .timeout_connect(Duration::from_secs(1))
+                .timeout_read(Duration::from_secs(1))
+                .build(),
+        }
+    }
+
+    /// Send a log entry to the server.
+    ///
+    /// Any errors are swallowed so that logging is effectively optional.
+    pub fn log<T: Serialize>(&self, entry: &T) {
+        let _ = self
+            .agent
+            .post(&self.url)
+            .set("Content-Type", "application/json")
+            .send_json(entry);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,15 @@
   "scripts": {
     "start-harmonic-nxo-gui-dev":".\\__git_bash.bat scripts/start-harmonic-nxo-gui-dev.sh",
     "bundle-harmonic-nxo-release":".\\__git_bash.bat scripts/bundle-harmonic-nxo-release.sh"
-
+    ,"start-log-server":"node scripts/log-server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.11.0"
+  "packageManager": "pnpm@10.11.0",
+  "dependencies": {
+    "express": "^4.18.2",
+    "pino": "^8.17.0",
+    "pino-pretty": "^10.3.1"
+  }
 }

--- a/scripts/log-server.js
+++ b/scripts/log-server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const pino = require('pino');
+
+const logger = pino({
+  transport: {
+    target: 'pino-pretty',
+    options: { colorize: true }
+  }
+});
+
+const app = express();
+app.use(express.json());
+
+app.post('/log', (req, res) => {
+  logger.info(req.body);
+  res.sendStatus(200);
+});
+
+const PORT = process.env.PORT || 9099;
+app.listen(PORT, () => {
+  console.log(`Logging server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- explain how the logging server errors are ignored in README
- document fail-safe behaviour in `remote_logging.rs`

## Testing
- `pnpm install` *(fails: Forbidden 403)*
- `cargo check --manifest-path custom_plugins/harmonic_nxo/Cargo.toml` *(fails: failed to fetch crates)*


------
https://chatgpt.com/codex/tasks/task_e_68847cd83f40832993425adb7865d1e1