### PR TITLE
Persist editor state via SynthParams

### DIFF
--- a/custom_plugins/harmonic_nxo/src/lib.rs
+++ b/custom_plugins/harmonic_nxo/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
 
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{self, json};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -110,6 +110,10 @@ struct PluginParams {
     #[id = "gain"]
     pub gain: FloatParam,
     gain_value_changed: Arc<AtomicBool>,
+    #[persist = "lua_code"]
+    pub lua_code: Arc<Mutex<String>>,
+    #[persist = "nxo_definition"]
+    pub nxo_definition: Arc<Mutex<String>>,
 }
 
 impl Default for PluginParams {
@@ -135,6 +139,18 @@ impl Default for PluginParams {
             .with_unit(" dB")
             .with_callback(param_callback.clone()),
             gain_value_changed,
+            lua_code: Arc::new(Mutex::new(include_str!("../web-gui/src/exampleLua/guitar.lua").to_string())),
+            nxo_definition: Arc::new(Mutex::new(serde_json::to_string(&{
+                let mut map = HashMap::new();
+                map.insert("1".to_string(), RawOscillatorParams {
+                    v: DEFAULT_V,
+                    a: DEFAULT_A,
+                    d: DEFAULT_D,
+                    s: DEFAULT_S,
+                    r: DEFAULT_R,
+                });
+                map
+            }).unwrap())),
         }
     }
 }
@@ -145,8 +161,13 @@ enum Action {
     Init,
     QueryCargoPackageVersion,
     QueryGain,
+    QueryLuaCode,
+    QueryNxoDefinition,
     SetGainDB {
         gain: f32,
+    },
+    SetLuaCode {
+        code: String,
     },
     SetNxoDefinition {
         definition: HashMap<String, RawOscillatorParams>,
@@ -259,13 +280,23 @@ pub struct HarmonicNxo {
 
 impl Default for HarmonicNxo {
     fn default() -> Self {
+        let params = Arc::new(PluginParams::default());
+        let initial_nxo = {
+            if let Ok(def) = serde_json::from_str::<HashMap<String, RawOscillatorParams>>(
+                &params.nxo_definition.lock().unwrap()
+            ) {
+                NxoDefinition::try_from(def).unwrap_or_default()
+            } else {
+                NxoDefinition::default()
+            }
+        };
         Self {
-            params: Arc::new(PluginParams::default()),
+            params,
             sample_rate: 44100.0,
             voices: Vec::new(),
             active_voices: HashMap::new(),
             queue: VecDeque::new(),
-            nxo_definition: Arc::new(Mutex::new(NxoDefinition::default())),
+            nxo_definition: Arc::new(Mutex::new(initial_nxo)),
             ts: 0,
             midi_states: Arc::new((0..128).map(|_| AtomicBool::new(false)).collect()),
             last_midi_send: Arc::new(Mutex::new(Instant::now())),
@@ -301,6 +332,13 @@ impl Plugin for HarmonicNxo {
         _context: &mut impl InitContext<Self>,
     ) -> bool {
         self.sample_rate = config.sample_rate;
+        if let Ok(def) = serde_json::from_str::<HashMap<String, RawOscillatorParams>>(
+            &self.params.nxo_definition.lock().unwrap()
+        ) {
+            if let Ok(nxo) = NxoDefinition::try_from(def) {
+                *self.nxo_definition.lock().unwrap() = nxo;
+            }
+        }
         true
     }
 
@@ -394,9 +432,15 @@ impl Plugin for HarmonicNxo {
                                 setter.end_set_parameter(&params.gain);
                             }
 
+                            Action::SetLuaCode { code } => {
+                                *params.lua_code.lock().unwrap() = code;
+                            }
+
                             Action::SetNxoDefinition { definition } => {
                                 if let Ok(nxo) = NxoDefinition::try_from(definition.clone()) {
                                     *nxo_def.lock().unwrap() = nxo;
+                                    *params.nxo_definition.lock().unwrap() =
+                                        serde_json::to_string(&definition).unwrap();
                                     logger.log(&json!({
                                         "event": "SetNxoDefinition",
                                         "definition": definition
@@ -418,6 +462,23 @@ impl Plugin for HarmonicNxo {
                                     "type": "RespondGain",
                                     "gain": params.gain.value()
                                 }));
+                            }
+                            Action::QueryLuaCode => {
+                                let code = params.lua_code.lock().unwrap().clone();
+                                ctx.send_json(json!({
+                                    "type": "RespondLuaCode",
+                                    "code": code
+                                }));
+                            }
+                            Action::QueryNxoDefinition => {
+                                if let Ok(def) = serde_json::from_str::<HashMap<String, RawOscillatorParams>>(
+                                    &params.nxo_definition.lock().unwrap()
+                                ) {
+                                    ctx.send_json(json!({
+                                        "type": "RespondNxoDefinition",
+                                        "definition": def
+                                    }));
+                                }
                             }
                         }
                     } else {

--- a/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
+++ b/custom_plugins/harmonic_nxo/web-gui/src/App.tsx
@@ -19,6 +19,7 @@ import {
 function App() {
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const workerRef = useRef<Worker>(undefined);
+  const [code, setCode] = useState<string>(exampleLuaGuitar);
   const [compileError, setCompileError] = useState<string | null>(null);
   const [compileResult, setCompileResult] = useState<NXODefinition | null>(
     null
@@ -34,6 +35,21 @@ function App() {
   const handleEditorDidMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
   };
+
+  const sendCodeToPlugin = useMemo(
+    () =>
+      lodash.debounce(
+        (c: string) => {
+          const win = window as object as NIHPlugWebviewWindow;
+          if (typeof win.sendToPlugin === "function") {
+            win.sendToPlugin({ type: "SetLuaCode", code: c });
+          }
+        },
+        100,
+        { trailing: true }
+      ),
+    []
+  );
 
   useEffect(() => {
     workerRef.current = new Worker(
@@ -117,6 +133,12 @@ Return value should be a lua table which is akin to the following typescript typ
       RespondGain: async (payload: { gain: number }) => {
         setGain(payload.gain);
       },
+      RespondLuaCode: async (payload: { code: string }) => {
+        setCode(payload.code);
+      },
+      RespondNxoDefinition: async (payload: { definition: NXODefinition }) => {
+        setCompileResult(payload.definition);
+      },
       MidiStateUpdate: async (payload: { states: boolean[] }) => {
         if (midiStatesBackupRef.current.some((s) => s)) {
           setMidiStates(payload.states);
@@ -154,6 +176,12 @@ Return value should be a lua table which is akin to the following typescript typ
     });
     (window as object as NIHPlugWebviewWindow).sendToPlugin({
       type: "QueryGain",
+    });
+    (window as object as NIHPlugWebviewWindow).sendToPlugin({
+      type: "QueryLuaCode",
+    });
+    (window as object as NIHPlugWebviewWindow).sendToPlugin({
+      type: "QueryNxoDefinition",
     });
   }, [ipcReady]);
 
@@ -302,7 +330,6 @@ Return value should be a lua table which is akin to the following typescript typ
             }
           `}
           onClick={() => {
-            const code = editorRef.current?.getValue() ?? "";
             setCompileError(null);
             setCompileResult(null);
             workerRef.current?.postMessage({ id: Date.now(), code });
@@ -317,7 +344,12 @@ Return value should be a lua table which is akin to the following typescript typ
           theme="vs-dark"
           height="100%"
           defaultLanguage="lua"
-          defaultValue={exampleLuaGuitar}
+          value={code}
+          onChange={(v) => {
+            const val = v ?? "";
+            setCode(val);
+            sendCodeToPlugin(val);
+          }}
           onMount={handleEditorDidMount}
           options={{
             wordWrap: "on",


### PR DESCRIPTION
## Summary
- add lua code and NXO definition persistent fields to plugin parameters
- restore saved NXO definition at startup
- update editor event loop to manage new param messages
- sync editor code via debounced messages

## Testing
- `pnpm lint` *(fails: cannot find module '@eslint/js')*
- `cargo check -p harmonic_nxo --offline` *(fails: failed to load dependency `assert_no_alloc` due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_6888670a0034832980b817c39f610155