### PR TITLE
Adapt sample rate using BufferConfig

### DIFF
--- a/custom_plugins/harmonic_nxo/src/lib.rs
+++ b/custom_plugins/harmonic_nxo/src/lib.rs
@@ -332,6 +332,9 @@ impl Plugin for HarmonicNxo {
         _context: &mut impl InitContext<Self>,
     ) -> bool {
         self.sample_rate = config.sample_rate;
+        for voice in &mut self.voices {
+            voice.sample_rate = self.sample_rate;
+        }
         if let Ok(def) = serde_json::from_str::<HashMap<String, RawOscillatorParams>>(
             &self.params.nxo_definition.lock().unwrap()
         ) {
@@ -340,6 +343,12 @@ impl Plugin for HarmonicNxo {
             }
         }
         true
+    }
+
+    fn reset(&mut self) {
+        for voice in &mut self.voices {
+            voice.sample_rate = self.sample_rate;
+        }
     }
 
     fn process(


### PR DESCRIPTION
## Summary
- make HarmonicNxo update all voices' sample rate from the host's buffer configuration
- update voices again on plugin reset

## Testing
- `cargo test --workspace --all-targets` *(fails: failed to get `assert_no_alloc` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688905e497488329b3b77c2b1485c123